### PR TITLE
Corretto import notebook

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Setup steps
+2. Run function/script '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+- conda environment
+- involved packages
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/dlproject/__init__.py
+++ b/dlproject/__init__.py
@@ -1,2 +1,2 @@
-import models
-import data
+from . import models
+from . import data

--- a/dlproject/data/__init__.py
+++ b/dlproject/data/__init__.py
@@ -1,1 +1,1 @@
-from mnist_dataset import MNISTDatasetBuilder
+from .mnist_dataset import MNISTDatasetBuilder

--- a/dlproject/models/__init__.py
+++ b/dlproject/models/__init__.py
@@ -1,1 +1,1 @@
-from simple_model import SimpleAutoencoder
+from .simple_model import SimpleAutoencoder

--- a/simple_model.ipynb
+++ b/simple_model.ipynb
@@ -49,6 +49,22 @@
    "execution_count": null,
    "outputs": [],
    "source": [
+    "!git clone https://github.com/peiva-git/deep_learning_project.git\n",
+    "%cd deep_learning_project\n",
+    "!pip install -e ."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "import dlproject as dlp"
    ],
    "metadata": {


### PR DESCRIPTION
Non essendo il modulo custom disponibile su PyPi, non è possibile installarlo direttamente col comando pip ma bisogna prima importarlo dal repository.

Per fare prove in locale con notebook Jupyter:
- spostare il notebook in una cartella temporanea (ad esempio `/tmp`)
- da terminale, attivare l'ambiente conda col package jupyter installato (`conda activate dl-tf`)
- da terminale, eseguire `jupyter notebook NOMEFILE.ipynb`